### PR TITLE
Use regex to extract video ids from urls

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   </div>
 
   <div class="container">
-    <p class="center">Paste in Unlisted "youtube.com" videoIDs (not URLs) seperated by a new line.</p>
+    <p class="center">Paste in Unlisted YouTube video IDs or URLs seperated by a new line.</p>
 
     <div class="center">
         <textarea id="urls"></textarea>

--- a/script.js
+++ b/script.js
@@ -4,22 +4,53 @@ const descriptionTextBox = document.getElementById("description");
 const submitButton = document.getElementById("submitButton");
 
 submitButton.addEventListener("click", async (event) => {
-    if (textBox.value.includes("/")) {
-        alert("Please use the videoIDs instead of URLs");
+    let videoIDs = [];
+    const urls = textBox.value.split(/\r?\n/g);
+    const rejects = [];
+
+    for (let i = 0; i < urls.length; i++) {
+        const url = urls[i].trim();
+        if (url.length === 0) continue;
+
+        const match = /^(?:(?:https?:\/\/)?(?:www\.)?(?:(?:(?:m\.)?youtube\..{2,6}|youtube-nocookie\.com)\/(?:watch\?(?:.+&)?v=|embed\/)|youtu\.be\/))?([a-zA-Z0-9_\-]{11})(?:$|\/|\?|&)/.exec(url);
+
+        if (!match || !match[1]) {
+            rejects.push(url);
+            continue;
+        }
+
+        videoIDs.push(match[1]);
+    }
+
+    if (rejects.length > 0) {
+        const msg = [`Please correct the following ${rejects.length} invalid line${rejects.length === 1 ? '' : 's'}:`];
+        msg.push(...rejects.slice(0, 5));
+        if (rejects.length > 5) msg.push(`(${rejects.length - 5} more)`);
+        alert(msg.join('\n'));
         return;
     }
-    
-    const urls = textBox.value.split("\n");
+
+    let duplicateCount = 0;
+    {
+        const dupes = new Set();
+        videoIDs = videoIDs.filter((id) => {
+            const found = dupes.has(id);
+            dupes.add(id);
+            if (found) duplicateCount++;
+            return !found;
+        });
+    }
+    const duplicateMsg = duplicateCount === 0 ? '' : " (ignoring " + duplicateCount + " duplicates)"
     
     const status = document.getElementById("status");
-    status.innerText = "0/" + urls.length;
+    status.innerText = "0/" + videoIDs.length + duplicateMsg;
     
     
-    for (let i = 0; i < urls.length; i++) {
+    for (let i = 0; i < videoIDs.length; i++) {
         await fetch("https://sponsor.ajay.app/api/unlistedVideo", {
             method: "POST",
             body: JSON.stringify({
-                videoID: urls[i]
+                videoID: videoIDs[i]
             }),
             headers: {
                 'Content-Type': 'application/json'
@@ -28,7 +59,7 @@ submitButton.addEventListener("click", async (event) => {
             alert("Submission failed: \n\n" + err);
         });
         
-        status.innerText = (i + 1) + "/" + urls.length;
+        status.innerText = (i + 1) + "/" + videoIDs.length + duplicateMsg;
     }
     
     status.innerText = "Done!";


### PR DESCRIPTION
Allows parsing out video ids from URLs. including the following forms:

- `http://www.youtube.com/watch?v=<id>`
- `youtube.com/embed/<id>`
- `https://youtu.be/<id>`
- `youtu.be/<id>`

This PR should make the tool easier to use for people manually filtering their playlists.

The list is validated and deduplicated prior to being sent to the server. Whitespace is trimmed. If found, the first 5 invalid lines are listed as an alert. No videos can be submitted before correcting the error.

Pasting in pure video ids still works. Parsing a list of 1000 video ids is practically instant.